### PR TITLE
Support package list generation for Leap 42.1/2 Ports

### DIFF
--- a/doit.sh
+++ b/doit.sh
@@ -90,12 +90,14 @@ for arch in $arches; do
     fi
    fi
 
-   #if test "$proj" = "Leap:42.1" ;then
-     # As we do not have bundle-lang packages, we want to get rid of all -lang on the 'installation images' to save the space
-     for file in gnome_cd-default gnome_cd-x11-default kde4_cd-base-default kde4_cd-default x11_cd; do
-       sed -i '/.*-lang$/d' output/opensuse/$proj/$file.${arch}.list
-     done
-   #fi
+   if $(is_x86 $arch); then
+     #if test "$proj" = "Leap:42.1" ;then
+        # As we do not have bundle-lang packages, we want to get rid of all -lang on the 'installation images' to save the space
+        for file in gnome_cd-default gnome_cd-x11-default kde4_cd-base-default kde4_cd-default x11_cd; do
+          sed -i '/.*-lang$/d' output/opensuse/$proj/$file.${arch}.list
+        done
+      #fi
+   fi
 
     # first flash
     : > opensuse/$proj/dvd-1.$arch.suggests

--- a/opensuse/Leap:42.1/dvd-1
+++ b/opensuse/Leap:42.1/dvd-1
@@ -47,7 +47,7 @@ job lock name xen-tools-domU
 job install provides pattern() = rest_dvd
 job install provides pattern() = devel_gnome
 job install name xfce4-panel
-job install name elilo #!ppc64 # !ppc64le
+job install name elilo #!ppc64 # !ppc64le # !aarch64
 job install name efibootmgr # !i586 # !ppc64 # !ppc64le
 job install name postgresql
 job install name postgresql-devel

--- a/opensuse/Leap:42.1/dvd-2
+++ b/opensuse/Leap:42.1/dvd-2
@@ -18,7 +18,7 @@ job install name myspell-german-old
 #TODO job install name squid
 job install name icewm-default
 job install name apper
-job install name libreoffice-kde4 # !ppc64 # !ppc64le
+job install name libreoffice-kde4 # !ppc64 # !ppc64le # !aarch64
 job lock name libicu50-32bit # !ppc64le
 
 job install provides pattern() = x11_yast

--- a/opensuse/Leap:42.2/dvd-1
+++ b/opensuse/Leap:42.2/dvd-1
@@ -47,7 +47,7 @@ job lock name xen-tools-domU
 job install provides pattern() = rest_dvd
 job install provides pattern() = devel_gnome
 job install name xfce4-panel
-job install name elilo #!ppc64 # !ppc64le
+job install name elilo # !ppc64 # !ppc64le # !aarch64
 job install name efibootmgr # !i586 # !ppc64 # !ppc64le
 job install name postgresql
 job install name postgresql-devel

--- a/opensuse/Leap:42.2/dvd-2
+++ b/opensuse/Leap:42.2/dvd-2
@@ -19,7 +19,7 @@ job install name myspell-german-old
 job install name icewm-default
 # FIXME: currently broken
 #job install name apper
-job install name libreoffice-kde4 # !ppc64 # !ppc64le
+job install name libreoffice-kde4 # !ppc64 # !ppc64le # !aarch64
 job lock name libicu50-32bit # !ppc64le
 
 job install provides pattern() = x11_yast


### PR DESCRIPTION
The image based installations are only available for x86_64
and a couple of packages (elilo, libreoffice) are currently
excluded from build for aarch64.