### PR TITLE
Skip mokutil on aarch64 as well

### DIFF
--- a/opensuse/Leap:42.2/dvd-1
+++ b/opensuse/Leap:42.2/dvd-1
@@ -52,7 +52,7 @@ job install provides pattern() = rest_dvd
 job install name xfce4-panel
 job install name elilo #!ppc64 # !ppc64le # !aarch64
 job install name efibootmgr # !i586 # !ppc64 # !ppc64le
-job install name mokutil # !i586 # !ppc64 # !ppc64le
+job install name mokutil # !i586 # !ppc64 # !ppc64le # !aarch64
 job install name postgresql
 job install name postgresql-devel
 job install name postgresql-contrib


### PR DESCRIPTION
This is slightly pointless, the package is exclusivearch x86_64
and doesn't make any sense on any other architecture