### PR TITLE
Reenable libreoffice for aarch64 (bsc#1057344)

### DIFF
--- a/opensuse/Factory/dvd-2
+++ b/opensuse/Factory/dvd-2
@@ -14,7 +14,7 @@ job install name xerces-j2-xml-apis
 job install name atftp
 job install name squid
 job install name icewm-default
-job install name libreoffice-kde4 # !ppc64 # !ppc64le # !aarch64 # !s390x
+job install name libreoffice-kde4 # !ppc64 # !ppc64le # !s390x
 job lock name libicu50-32bit # !ppc64le # !aarch64
 
 job install provides pattern() = x11_yast


### PR DESCRIPTION
It is meanwhile building successfully, and it pulls in
icedtea-web which is tested by openQA (I love those captain obvious
dependencies)