### PR TITLE
Add make_path in gen.pl

### DIFF
--- a/gen.pl
+++ b/gen.pl
@@ -1,6 +1,7 @@
 #! /usr/bin/perl
 
 use File::Basename;
+use File::Path qw(make_path);
 
 my $file = $ARGV[0] || die 'need file';
 my $arch = $ARGV[1] || die 'need arch';
@@ -67,6 +68,7 @@ while ( <TS> ) {
 exit(1) if ($ret);
 
 close(TS);
+make_path(dirname("output/$file"));
 open(OUT, ">", "output/$file.$arch.list");
 for my $pkg (sort keys %installs) {
   print OUT "$pkg\n";


### PR DESCRIPTION
```
required to avoid following error,
when called in a clean environment.
===
$./doit.sh Factory:PowerPC
generate dvds for Factory:PowerPC standard at
Mon Dec  4 12:03:47 CET 2017
mv: cannot stat 'output/opensuse/Factory:PowerPC/dvd-1.ppc64.suggests':
No such file or directory
===

for issue https://github.com/openSUSE/package-lists/issues/21

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>
```