### PR TITLE
call installcheck for all archi not only x86-64

### DIFF
--- a/commit.sh
+++ b/commit.sh
@@ -78,11 +78,11 @@ if [ "$proj" = "Leap:15.0" ]; then
   osc -q ci -m "auto update" osc/openSUSE:$proj/package-lists-openSUSE-images | grep -v nothing
 fi
 
-if [ -f trees/openSUSE:$proj-$repo-x86_64.solv ]; then
+if [ -f trees/openSUSE:$proj-$repo-$arch.solv ]; then
   file="openSUSE:$proj.installcheck"
   remote="/source/openSUSE:$proj:Staging/dashboard/installcheck"
 
-  installcheck x86_64 --withobsoletes trees/openSUSE:$proj-$repo-x86_64.solv > "$file"
+  installcheck $arch --withobsoletes trees/openSUSE:$proj-$repo-$arch.solv > "$file"
   if [ "$(< "$file")" != "$(osc api "$remote")" ] ; then
     osc -d api -X PUT -f "$file" "$remote"
   fi


### PR DESCRIPTION
I do no know how the already existing installcheck is accessed from x86_64 dashboard (1)

anyway this patch suggest to save it for all arches.

(1) https://build.opensuse.org/project/dashboard/openSUSE:Factory
https://build.opensuse.org/package/view_file/openSUSE:Factory:Staging/dashboard/installcheck?expand=1


