### PR TITLE
remove xerces-j2 subpackages

### DIFF
--- a/opensuse/Factory/dvd-1
+++ b/opensuse/Factory/dvd-1
@@ -30,8 +30,6 @@ namespace namespace:language(el) @SYSTEM
 #INCLUDE dvd-1.ppc64le.suggests # !x86_64 # !i586 # !ppc64 # !aarch64
 #INCLUDE dvd-1.aarch64.suggests # !x86_64 # !i586 # !ppc64 # !ppc64le
 
-job lock name xerces-j2-xml-resolver
-job lock name xerces-j2-xml-apis
 job lock name gnu-javamail
 job lock name gnuchess
 job lock name atftp

--- a/opensuse/Factory/dvd-2
+++ b/opensuse/Factory/dvd-2
@@ -9,8 +9,6 @@ job lock name apache2-prefork
 job lock name postgresql
 
 job install name sendmail
-job install name xerces-j2-xml-resolver
-job install name xerces-j2-xml-apis
 job install name atftp
 job install name squid
 job install name icewm-default

--- a/opensuse/Factory/dvd-addon_lang
+++ b/opensuse/Factory/dvd-addon_lang
@@ -190,8 +190,6 @@ namespace namespace:language(zh_TW) @SYSTEM
 namespace namespace:language(zu) @SYSTEM
 
 
-job lock name xerces-j2-xml-resolver
-job lock name xerces-j2-xml-apis
 job lock name gnu-javamail
 job lock name novell-NLDAPsdk-dyn
 job lock name gnuchess

--- a/opensuse/Factory/dvd9
+++ b/opensuse/Factory/dvd9
@@ -18,8 +18,6 @@ namespace namespace:language(ru) @SYSTEM
 namespace namespace:language(cs) @SYSTEM
 namespace namespace:language(hu) @SYSTEM
 
-job lock name xerces-j2-xml-resolver
-job lock name xerces-j2-xml-apis
 job lock name gnu-javamail
 job lock name novell-NLDAPsdk-dyn
 job lock name gnuchess


### PR DESCRIPTION
These were dropped in the version update to Factory
in rq 657128